### PR TITLE
Fixed problem with deep merge trying to merge arrays

### DIFF
--- a/seamless-immutable.js
+++ b/seamless-immutable.js
@@ -33,6 +33,10 @@
     }
   }
 
+  function isObject(target) {
+    return target !== null && typeof target === "object" && !(target instanceof Array);
+  }
+
   var mutatingObjectMethods = [
     "setPrototypeOf"
   ];
@@ -246,7 +250,7 @@
           // Avoid false positives due to (NaN !== NaN) evaluating to true
           (immutableValue === immutableValue)));
 
-      if (deep && currentObj[key] !== null && typeof currentObj[key] === "object" && typeof immutableValue === "object" ) {
+      if (deep && isObject(currentObj[key]) && isObject(immutableValue)) {
         result[key] = currentObj[key].merge(immutableValue, config);
       } else {
         result[key] = immutableValue;

--- a/test/ImmutableObject/test-merge.js
+++ b/test/ImmutableObject/test-merge.js
@@ -192,6 +192,16 @@ module.exports = function() {
       assert.deepEqual(actualDeep, expectedDeep);
     });
 
+    it("merges deep on only objects", function() {
+      var original = Immutable({id: 3, name: "three", valid: true, a: {id: 2}, b: [50], x: [1, 2], sub: {z: [100]}});
+      var toMerge = {id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [3, 4], sub: {y: [10, 11], z: [101, 102]}};
+
+      var expected = Immutable({id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [3, 4], sub: {z: [101, 102], y: [10, 11]}});
+      var actual   = original.merge(toMerge, {deep: true});
+
+      assert.deepEqual(actual, expected);
+    });
+
     describe("when passed a single object", function() {
       generateMergeTestsFor([TestUtils.ComplexObjectSpecifier()]);
     });


### PR DESCRIPTION
Since `typeof [] === "object"` then deep merge would try to to run `merge` on arrays which fails. I added a helper method called `isObject` that is used when deciding if `merge` should continue deeper in deep mode.

I have added test cases for when the key is of the following types:
 1. array and array
 2. array and object
 3. object and array

`isObject` checks that the value isn't `null`, that the `typeof` is `object` and that it isn't an array. As far as I can see that should cover everything.