### PR TITLE
Custom merger function

### DIFF
--- a/test/ImmutableObject/test-merge.js
+++ b/test/ImmutableObject/test-merge.js
@@ -233,12 +233,20 @@ module.exports = function() {
       generateMergeTestsFor([TestUtils.ComplexObjectSpecifier()], {deep: true});
     });
 
+    describe("when passed a single object with a custom merger", function() {
+      generateMergeTestsFor([TestUtils.ComplexObjectSpecifier()], {merger: arrayMerger()});
+    });
+
     describe("when passed an array of objects", function() {
       generateMergeTestsFor([generateArrayOfObjects]);
     });
 
     describe("when passed an array of objects with deep set to true", function() {
       generateMergeTestsFor([generateArrayOfObjects], {deep: true});
+    });
+
+    describe("when passed an array of objects with a custom merger", function() {
+      generateMergeTestsFor([generateArrayOfObjects], {merger: arrayMerger()});
     });
   });
 };

--- a/test/ImmutableObject/test-merge.js
+++ b/test/ImmutableObject/test-merge.js
@@ -202,6 +202,29 @@ module.exports = function() {
       assert.deepEqual(actual, expected);
     });
 
+    function arrayMerger(thisValue, providedValue) {
+      if (thisValue instanceof Array && providedValue instanceof Array) {
+        return thisValue.concat(providedValue);
+      }
+    }
+
+    it("merges with a custom merger when the config tells it to", function() {
+      var expected = Immutable({all: "your base", are: {belong: "to us"}, you: ['have', 'no', 'chance', 'to', 'survive']});
+      var actual = Immutable({all: "your base", are: {belong: "to us"}, you: ['have', 'no']}).merge({you: ['chance', 'to', 'survive']}, {merger: arrayMerger});
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it("merges deep with a custom merger when the config tells it to", function() {
+      var original = Immutable({id: 3, name: "three", valid: true, a: {id: 2}, b: [50], x: [1, 2], sub: {z: [100]}});
+      var toMerge = {id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [3, 4], sub: {y: [10, 11], z: [101, 102]}};
+
+      var expected = Immutable({id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [1, 2, 3, 4], sub: {z: [100, 101, 102], y: [10, 11]}});
+      var actual   = original.merge(toMerge, {deep: true, merger: arrayMerger});
+
+      assert.deepEqual(actual, expected);
+    });
+
     describe("when passed a single object", function() {
       generateMergeTestsFor([TestUtils.ComplexObjectSpecifier()]);
     });


### PR DESCRIPTION
This allows you to pass a custom merger function that can override the merge of a property if the conditions are right. See #26 for details.

Any thoughts or optimizations I can do?

This fixes #26.