### PR TITLE
Give custom mergers access to the config object

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -247,7 +247,7 @@
     // in a change from this object's value at that key, set anyChanges = true.
     function addToResult(currentObj, otherObj, key) {
       var immutableValue = Immutable(otherObj[key]);
-      var mergerResult = merger && merger(currentObj[key], immutableValue);
+      var mergerResult = merger && merger(currentObj[key], immutableValue, config);
 
       anyChanges = anyChanges ||
         mergerResult !== undefined ||


### PR DESCRIPTION
I have been doing some work with deep merge and custom mergers recently and I have a few use cases where the custom merger needs access to the merge config object.

This is mainly because the custom merger might do an internal merge and then it needs to pass down the config so that merge uses the same rules. One example is a merger that takes two arrays and merges objects in them based on id properties.

The fix for this is a one liner where the config object is passed in to the merger as the last parameter.