### PR TITLE
Custom merger equality

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -252,6 +252,7 @@
     function addToResult(currentObj, otherObj, key) {
       var immutableValue = Immutable(otherObj[key]);
       var mergerResult = merger && merger(currentObj[key], immutableValue, config);
+      if (merger && mergerResult && mergerResult === currentObj[key]) return;
 
       anyChanges = anyChanges ||
         mergerResult !== undefined ||

--- a/test/ImmutableObject/test-merge.js
+++ b/test/ImmutableObject/test-merge.js
@@ -227,6 +227,21 @@ module.exports = function(config) {
       assert.deepEqual(actual, expected);
     });
 
+    it("merges with a custom merger that returns the current object the result is the same as the original", function() {
+      var data = {id: 3, name: "three", valid: true, a: {id: 2}, b: [50], x: [1, 2], sub: {z: [100]}};
+      var original = Immutable(data);
+      var actualWithoutMerger = original.merge(data);
+      assert.notEqual(original, actualWithoutMerger);
+
+      var config = {
+        merger: function(current, other) {
+          return current;
+        }
+      };
+      var actualWithMerger = original.merge(data, config);
+      assert.equal(original, actualWithMerger);
+    });
+
     describe("when passed a single object", function() {
       generateMergeTestsFor([TestUtils.ComplexObjectSpecifier()]);
     });


### PR DESCRIPTION
When a custom merger returns a result that is the same as in the `currentObj` we can aboirt `addToResult` since there are nothing more we have to do. And we don't have to flag that any changes have been done.

This is a partial fix to #40. With this addition a custom merger can be used to fullfill the requirements. Check the issue for the details.

In the `if` we check the `merger` to abort early, then we need to check if there is a `mergeResult` otherwise the last part, `mergerResult === currentObj[key]`, would be true when the custom merger returns undefined and it is a value that is only available in `otherObj` and not `currentObj`.

