### PR TITLE
Make package.json main point to src/seamless-immutable.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "seamless-immutable",
   "version": "3.0.0",
   "description": "Immutable data structures for JavaScript which are backwards-compatible with normal JS Arrays and Objects.",
-  "main": "seamless-immutable.development.js",
+  "main": "src/seamless-immutable.js",
   "devDependencies": {
     "chai": "3.2.0",
     "coveralls": "2.11.2",


### PR DESCRIPTION
As it stands, if I `require('seamless-immutable')` I get the development version, and if I want to get the prod version, I have to change my code.  If `main` in `package.json` simply pointed to `src/seamless-immutable.js`, then I wouldn't have to change my code, and whether the prod or dev version gets used simply depends on `process.env.NODE_ENV` (which `src/seamless-immutable.js` is using anyway, so I don't understand why it's not the main).

As I'm sure you already know, this change would make it work just the same as React, and for those of us who are using Webpack with dev/prod configs for React, they would work right off the bat with seamless-immutable if you make this change.