### PR TITLE
Start freezing dates and handle them as Object and Array

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -1,4 +1,4 @@
-(function(){
+(function() {
   "use strict";
 
   function addPropertyTo(target, methodName, value) {
@@ -51,6 +51,12 @@
 
   var nonMutatingArrayMethods = nonMutatingObjectMethods.concat([
     "map", "filter", "slice", "concat", "reduce", "reduceRight"
+  ]);
+
+  var mutatingDateMethods = mutatingObjectMethods.concat([
+    "setDate", "setFullYear", "setHours", "setMilliseconds", "setMinutes", "setMonth", "setSeconds",
+    "setTime", "setUTCDate", "setUTCFullYear", "setUTCHours", "setUTCMilliseconds", "setUTCMinutes",
+    "setUTCMonth", "setUTCSeconds", "setYear"
   ]);
 
   function ImmutableError(message) {
@@ -107,6 +113,16 @@
     }
 
     return makeImmutable(array, mutatingArrayMethods);
+  }
+
+  function makeImmutableDate(date) {
+    addPropertyTo(date, "asMutable", asMutableDate);
+
+    return makeImmutable(date, mutatingDateMethods);
+  }
+
+  function asMutableDate() {
+    return new Date(this.getTime());
   }
 
   /**
@@ -174,7 +190,7 @@
 
     if(opts && opts.deep) {
       for(i = 0, length = this.length; i < length; i++) {
-        result.push( asDeepMutable(this[i]) );
+        result.push(asDeepMutable(this[i]));
       }
     } else {
       for(i = 0, length = this.length; i < length; i++) {
@@ -367,7 +383,7 @@
     } else if (obj instanceof Array) {
       return makeImmutableArray(obj.slice());
     } else if (obj instanceof Date) {
-      return makeImmutable(new Date(obj.getTime()));
+      return makeImmutableDate(new Date(obj.getTime()));
     } else {
       // Don't freeze the object we were given; make a clone and use that.
       var prototype = options && options.prototype;

--- a/test/Immutable.isImmutable.spec.js
+++ b/test/Immutable.isImmutable.spec.js
@@ -22,7 +22,8 @@ var getTestUtils = require("./TestUtils.js");
         "undefined": [true, JSC.literal(undefined)],
         "null": [true, JSC.literal(null)],
         "objects": [false, JSC.object()],
-        "arrays": [false, JSC.array()]
+        "arrays": [false, JSC.array()],
+        "dates": [false, JSC.literal(new Date())]
       }, function (tuple, type) {
         var expectImmutable = tuple[0];
         var specifier = tuple[1];

--- a/test/Immutable.spec.js
+++ b/test/Immutable.spec.js
@@ -25,6 +25,16 @@ var getTestUtils = require("./TestUtils.js");
         });
       });
 
+      it("makes an Immutable Date when passed a mutable Date", function () {
+        TestUtils.check(100, [JSC.literal(new Date())], function (mutable) {
+          var immutable = Immutable(mutable);
+
+          assert.deepEqual(immutable, mutable);
+          assert.isTrue(Immutable.isImmutable(immutable));
+          assert.isFalse(Immutable.isImmutable(mutable));
+        });
+      });
+
       it("makes an Immutable Object when passed a mutable object", function () {
         TestUtils.check(100, [JSC.object()], function (mutable) {
           var immutable = Immutable(mutable);
@@ -44,7 +54,7 @@ var getTestUtils = require("./TestUtils.js");
           assert.isTrue(Immutable.isImmutable(immutable));
           assert.isTrue(Immutable.isImmutable(immutable[1]))
         })
-      })
+      });
 
       it("doesn't fail when a function is defined on Array.prototype", function() {
         Array.prototype.veryEvilFunction = function() {};

--- a/test/ImmutableDate.spec.js
+++ b/test/ImmutableDate.spec.js
@@ -1,0 +1,20 @@
+var testAsMutable = require("./ImmutableDate/test-asMutable.js");
+var testCompat    = require("./ImmutableDate/test-compat.js");
+var devBuild      = require("../seamless-immutable.development.js");
+var prodBuild     = require("../seamless-immutable.production.min.js");
+var getTestUtils  = require("./TestUtils.js");
+
+[
+  {id: "dev",  name: "Development build", implementation: devBuild},
+  {id: "prod", name: "Production build",  implementation: prodBuild}
+].forEach(function(config) {
+  var Immutable = config.implementation;
+  var TestUtils = getTestUtils(Immutable);
+
+  describe(config.name, function () {
+    describe("ImmutableDate", function () {
+      testCompat(config);
+      testAsMutable(config);
+    });
+  });
+});

--- a/test/ImmutableDate/test-asMutable.js
+++ b/test/ImmutableDate/test-asMutable.js
@@ -1,0 +1,69 @@
+var JSC          = require("jscheck");
+var assert       = require("chai").assert;
+var _            = require("lodash");
+var getTestUtils = require("../TestUtils.js");
+
+module.exports = function(config) {
+  var Immutable = config.implementation;
+  var TestUtils = getTestUtils(Immutable);
+
+  describe("#asMutable", function() {
+    it("returns mutable Date from an immutable Date", function() {
+      var immutable = Immutable(new Date());
+      var mutable = immutable.asMutable();
+
+      assertNotArray(mutable);
+      assertCanBeMutated(mutable);
+      assert.isFalse(Immutable.isImmutable(mutable));
+      assert.deepEqual(immutable, mutable);
+      assert.equal(Object.keys(mutable).length, 0);
+    });
+
+    it("returns mutable Date from an immutable Date when using the deep flag", function() {
+      var immutable = Immutable(new Date());
+      var mutable = immutable.asMutable({deep: true});
+
+      assertNotArray(mutable);
+      assertCanBeMutated(mutable);
+      assert.isFalse(Immutable.isImmutable(mutable));
+      assert.deepEqual(immutable, mutable);
+      assert.equal(Object.keys(mutable).length, 0);
+    });
+
+    it("preserves prototypes after call to asMutable", function() {
+      var data = new Date();
+
+      var immutable = Immutable(data, {prototype: Date.prototype});
+      var result = immutable.asMutable();
+
+      assert.deepEqual(result, data);
+      TestUtils.assertHasPrototype(result, Date.prototype);
+    });
+
+  });
+
+  function assertCanBeMutated(obj) {
+    try {
+      var newElement = { foo: "bar" };
+      var originalKeyCount = Object.keys(obj).length;
+      var key = "__test__field__";
+
+      assert.equal(false, obj.hasOwnProperty(key));
+
+      obj[key] = newElement;
+
+      assert.equal(true, obj.hasOwnProperty(key));
+
+      assert.equal(obj[key], newElement);
+      assert.equal(Object.keys(obj).length, originalKeyCount + 1);
+
+      delete obj[key];
+    } catch(error) {
+      assert.fail("Exception when trying to verify that this object was mutable: " + JSON.stringify(obj));
+    }
+  }
+
+  function assertNotArray(obj) {
+    assert(!(obj instanceof Array), "Did not expect an Array, but got one. Got: " + JSON.stringify(obj))
+  }
+};

--- a/test/ImmutableDate/test-compat.js
+++ b/test/ImmutableDate/test-compat.js
@@ -1,0 +1,92 @@
+var JSC          = require("jscheck");
+var assert       = require("chai").assert;
+var _            = require("lodash");
+var getTestUtils = require("../TestUtils.js");
+
+function notParseableAsInt(str) {
+  return parseInt(str).toString() !== str;
+}
+
+module.exports = function(config) {
+  var Immutable = config.implementation;
+  var TestUtils = getTestUtils(Immutable);
+
+  var checkImmutableMutable = TestUtils.checkImmutableMutable(1, [JSC.literal(new Date())]);
+
+  describe("which is compatible with vanilla mutable Dates", function() {
+    it("is an instance of Date", function () {
+      checkImmutableMutable(function(immutable, mutable) {
+        assert.instanceOf(immutable, Date);
+      });
+    });
+
+    it("has the same keys as its mutable equivalent", function() {
+      checkImmutableMutable(function(immutable, mutable) {
+        // Exclude properties that can be parsed as 32-bit unsigned integers,
+        // as they have no sort order guarantees.
+        var immutableKeys = Object.keys(immutable).filter(notParseableAsInt);
+        var mutableKeys = Object.keys(mutable).filter(notParseableAsInt);
+
+        assert.deepEqual(immutableKeys, mutableKeys);
+      });
+    });
+
+    it("has a toString() method that works like a regular immutable's toString()", function() {
+      checkImmutableMutable(function(immutable, mutable) {
+        assert.strictEqual(immutable.toString(), mutable.toString());
+      });
+    });
+
+    it("supports being passed to JSON.stringify", function() {
+      TestUtils.check(1, [JSC.literal(new Date())], function(mutable) {
+        // Delete all the keys that could be parsed as 32-bit unsigned integers,
+        // as there is no guaranteed sort order for them.
+        for (var key in mutable) {
+          if (!notParseableAsInt(mutable[key])) {
+            delete mutable[key];
+          }
+        }
+
+        var immutable = Immutable(mutable);
+        assert.deepEqual(JSON.stringify(immutable), JSON.stringify(mutable));
+      });
+    });
+
+    if (config.id === "dev") {
+      it("is frozen", function () {
+        checkImmutableMutable(function(immutable, mutable) {
+          assert.isTrue(Object.isFrozen(immutable));
+        });
+      });
+    }
+
+    if (config.id === "prod") {
+      it("is frozen", function () {
+        checkImmutableMutable(function(immutable, mutable) {
+          assert.isFalse(Object.isFrozen(immutable));
+        });
+      });
+    }
+
+    it("is tagged as immutable", function() {
+      checkImmutableMutable(function(immutable, mutable) {
+        TestUtils.assertIsDeeplyImmutable(immutable);
+      });
+    });
+
+    [ // Add a "reports banned" claim for each mutating method on Date.
+      "setDate", "setFullYear", "setHours", "setMilliseconds", "setMinutes", "setMonth", "setSeconds",
+      "setTime", "setUTCDate", "setUTCFullYear", "setUTCHours", "setUTCMilliseconds", "setUTCMinutes",
+      "setUTCMonth", "setUTCSeconds", "setYear"
+    ].forEach(function(methodName) {
+      var description = "it throws an ImmutableError when you try to call its " +
+        methodName + "() method";
+
+      checkImmutableMutable(function(immutable, mutable, innerArray, obj) {
+        assert.throw(function() {
+          date[methodName].apply(date, methodArgs);
+        });
+      }, Immutable.ImmutableError);
+    });
+  });
+};


### PR DESCRIPTION
I don't use Dates myself in my data structures, but I thought I would give it a try to fix the handling of them as described in #46.

I have added all the test cases I could think of and it seems to work as expected. I haven't tried using it in any application or such, so some user testing would be appreciated.

I am also unsure of what the last thing in `test-compat.js` really does? For now I copied it from the array tests and adapted it for dates.

Make sure to run `grunt` to generate the prod and dev builds before testing.

This fixes #45 and #46.