### PR TITLE
Check for empty object

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -34,7 +34,7 @@
   }
 
   function isMergableObject(target) {
-    return target !== null && typeof target === "object" && !(target instanceof Array) && !(target instanceof Date);
+    return target !== null && typeof target === "object" && Object.keys(target).length > 0 && !(target instanceof Array) && !(target instanceof Date);
   }
 
   var mutatingObjectMethods = [


### PR DESCRIPTION
Adds a check to isMergableObject function that ensures it returns false for an empty object. Ping @rtfeldman 