### PR TITLE
Detect cycles during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ Immutable(new Square(2), {prototype: Square.prototype}).area();
 
 Beyond [the usual Object fare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#Methods_of_Object_instances), the following methods have been added.
 
+### Stack overflow protection
+
+Currently you can't construct Immutable from an object with circular references. To protect from ugly stack overflows, we provide a simple protection during development. We stop at suspiciously deep stack level and [show an error message][deep].
+
+If your objects are deep, but not circular, you can increase this level from default `64`. For example:
+
+```javascript
+Immutable(deepObject, null, 256);
+```
+
+[deep]: https://github.com/rtfeldman/seamless-immutable/wiki/Deeply-nested-object-was-detected
+
 ### merge
 
 ```javascript

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -497,7 +497,7 @@
     return makeImmutable(obj, mutatingObjectMethods);
   }
 
-  function Immutable(obj, options) {
+  function Immutable(obj, options, level) {
     if (isImmutable(obj)) {
       return obj;
     } else if (obj instanceof Array) {
@@ -512,9 +512,21 @@
           instantiatePlainObject : (function() { return Object.create(prototype); });
       var clone = instantiateEmptyObject();
 
+      if (process.env.NODE_ENV !== "production") {
+        if (level === undefined) {
+          level = 0;
+        }
+        if (level >= 64) {
+          throw new ImmutableError("Attempt to construct Immutable from a deeply nested object was detected." +
+            " Have you tried to wrap an object with circular references (e.g. React Component)?" +
+            " See https://github.com/rtfeldman/seamless-immutable/issues/73 for details.");
+        }
+        level += 1;
+      }
+
       for (var key in obj) {
         if (Object.getOwnPropertyDescriptor(obj, key)) {
-          clone[key] = Immutable(obj[key]);
+          clone[key] = Immutable(obj[key], undefined, level);
         }
       }
 

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -497,7 +497,7 @@
     return makeImmutable(obj, mutatingObjectMethods);
   }
 
-  function Immutable(obj, options, level) {
+  function Immutable(obj, options, stackRemaining) {
     if (isImmutable(obj)) {
       return obj;
     } else if (obj instanceof Array) {
@@ -513,18 +513,21 @@
       var clone = instantiateEmptyObject();
 
       if (process.env.NODE_ENV !== "production") {
-        level = level || 0;
-        if (level >= 64) {
+        /*jshint eqnull:true */
+        if (stackRemaining == null) {
+          stackRemaining = 64;
+        }
+        if (stackRemaining <= 0) {
           throw new ImmutableError("Attempt to construct Immutable from a deeply nested object was detected." +
             " Have you tried to wrap an object with circular references (e.g. React Component)?" +
             " See https://github.com/rtfeldman/seamless-immutable/issues/73 for details.");
         }
-        level += 1;
+        stackRemaining -= 1;
       }
 
       for (var key in obj) {
         if (Object.getOwnPropertyDescriptor(obj, key)) {
-          clone[key] = Immutable(obj[key], undefined, level);
+          clone[key] = Immutable(obj[key], undefined, stackRemaining);
         }
       }
 

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -519,8 +519,8 @@
         }
         if (stackRemaining <= 0) {
           throw new ImmutableError("Attempt to construct Immutable from a deeply nested object was detected." +
-            " Have you tried to wrap an object with circular references (e.g. React Component)?" +
-            " See https://github.com/rtfeldman/seamless-immutable/issues/73 for details.");
+            " Have you tried to wrap an object with circular references (e.g. React element)?" +
+            " See https://github.com/rtfeldman/seamless-immutable/wiki/Deeply-nested-object-was-detected for details.");
         }
         stackRemaining -= 1;
       }

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -513,9 +513,7 @@
       var clone = instantiateEmptyObject();
 
       if (process.env.NODE_ENV !== "production") {
-        if (level === undefined) {
-          level = 0;
-        }
+        level = level || 0;
         if (level >= 64) {
           throw new ImmutableError("Attempt to construct Immutable from a deeply nested object was detected." +
             " Have you tried to wrap an object with circular references (e.g. React Component)?" +

--- a/test/Immutable.spec.js
+++ b/test/Immutable.spec.js
@@ -98,6 +98,17 @@ var getTestUtils = require("./TestUtils.js");
           });
         });
       });
+
+      it("detects cycles", function() {
+        var obj = {};
+        obj.prop = obj;
+
+        if (config.id === 'prod') {
+          assert.throws(function() { Immutable(obj); }, RangeError);
+        } else {
+          assert.throws(function() { Immutable(obj); }, /deeply nested/);
+        }
+      });
     });
   });
 });

--- a/test/Immutable.spec.js
+++ b/test/Immutable.spec.js
@@ -109,6 +109,20 @@ var getTestUtils = require("./TestUtils.js");
           assert.throws(function() { Immutable(obj); }, /deeply nested/);
         }
       });
+
+      it("can configure stackRemaining", function() {
+        var mutable = {bottom: true};
+        _.range(65).forEach(function() {
+          mutable = {prop: mutable};
+        });
+        
+        if (config.id === 'prod') {
+          TestUtils.assertJsonEqual(mutable, Immutable(mutable));
+        } else {
+          assert.throws(function() { Immutable(mutable); }, /deeply nested/);
+          TestUtils.assertJsonEqual(mutable, Immutable(mutable, null, 66));
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
This throws development-only error when an object is too deeply nested.

Related issues: #73 and #16.