### PR TITLE
Add support for static Immutable methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ mutableArray // ["hello", "world", "!!!"]
 
 Returns a mutable copy of the array. For a deeply mutable copy, in which any instances of `Immutable` contained in nested data structures within the array have been converted back to mutable data structures, call `.asMutable({deep: true})` instead.
 
+### All object and array methods
+
+Every other methods on immutable objects and arrays can also be used as static
+methods of `Immutable`. For instance, the lines below are equivalent:
+
+```
+obj.setIn(['key'], value);
+
+Immutable.setIn(obj, ['key'], value);
+```
+
 ## Immutable Object
 
 Like a regular Object, but immutable! You can construct these by passing an

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -562,10 +562,47 @@
     }
   }
 
+  // Wrapper to allow the use of object methods as static methods of Immutable.
+  function toStatic(fn) {
+    function staticWrapper() {
+      var args = [].slice.call(arguments);
+      var self = args.shift();
+      return fn.apply(self, args);
+    }
+
+    return staticWrapper;
+  }
+
+  // Wrapper to allow the use of object methods as static methods of Immutable.
+  // with the additional condition of choosing which function to call depending
+  // if argument is an array or an object.
+  function toStaticObjectOrArray(fnObject, fnArray) {
+    function staticWrapper() {
+      var args = [].slice.call(arguments);
+      var self = args.shift();
+      if (Array.isArray(self)) {
+          return fnArray.apply(self, args);
+      } else {
+          return fnObject.apply(self, args);
+      }
+    }
+
+    return staticWrapper;
+  }
+
   // Export the library
   Immutable.from           = Immutable;
   Immutable.isImmutable    = isImmutable;
   Immutable.ImmutableError = ImmutableError;
+  Immutable.merge          = toStatic(merge);
+  Immutable.without        = toStatic(without);
+  Immutable.asMutable      = toStaticObjectOrArray(asMutableObject, asMutableArray);
+  Immutable.set            = toStaticObjectOrArray(objectSet, arraySet);
+  Immutable.setIn          = toStaticObjectOrArray(objectSetIn, arraySetIn);
+  Immutable.update         = toStatic(update);
+  Immutable.updateIn       = toStatic(updateIn);
+  Immutable.flatMap        = toStatic(flatMap);
+  Immutable.asObject       = toStatic(asObject);
 
   Object.freeze(Immutable);
 

--- a/test/ImmutableArray/test-set.js
+++ b/test/ImmutableArray/test-set.js
@@ -24,7 +24,7 @@ module.exports = function(config) {
         var index = JSC.integer(0, array.length);
         var newValue = JSC.any();
 
-        immutable = immutable.set(index, newValue);
+        immutable = Immutable.set(immutable, index, newValue);
         mutable[index] = newValue;
 
         TestUtils.assertJsonEqual(immutable, mutable);
@@ -54,7 +54,7 @@ module.exports = function(config) {
         mutable[idx][key] = value;
 
         TestUtils.assertJsonEqual(
-          immutable.setIn([idx, key], value),
+          Immutable.setIn(immutable, [idx, key], value),
           mutable
         );
       });

--- a/test/ImmutableArray/test-update.js
+++ b/test/ImmutableArray/test-update.js
@@ -27,7 +27,7 @@ module.exports = function(config) {
         var mutable = immutable.asMutable();
         var index = JSC.integer(0, array.length);
 
-        immutable = immutable.update(index, dummyUpdater);
+        immutable = Immutable.update(immutable, index, dummyUpdater);
         mutable[index] = dummyUpdater(mutable[index]);
 
         TestUtils.assertJsonEqual(immutable, mutable);
@@ -57,7 +57,7 @@ module.exports = function(config) {
         mutable[idx][key] = dummyUpdater(mutable[idx][key]);
 
         TestUtils.assertJsonEqual(
-          immutable.updateIn([idx, key], dummyUpdater),
+          Immutable.updateIn(immutable, [idx, key], dummyUpdater),
           mutable
         );
       });

--- a/test/ImmutableObject/test-asMutable.js
+++ b/test/ImmutableObject/test-asMutable.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
   describe("#asMutable", function() {
     it("returns an empty mutable oject from an empty immutable array", function() {
         var immutable = Immutable({});
-        var mutable = immutable.asMutable();
+        var mutable = Immutable.asMutable(immutable);
 
         assertNotArray(mutable);
         assertCanBeMutated(mutable);
@@ -23,7 +23,7 @@ module.exports = function(config) {
     it("returns a shallow mutable copy if not provided the deep flag", function() {
       check(100, [ TestUtils.TraversableObjectSpecifier ], function(obj) {
         var immutable = Immutable(obj);
-        var mutable = immutable.asMutable();
+        var mutable = Immutable.asMutable(immutable);
 
         assertNotArray(mutable);
         assertCanBeMutated(mutable);
@@ -60,7 +60,7 @@ module.exports = function(config) {
       var data = new TestClass({a: 1, b: 2});
 
       var immutable = Immutable(data, {prototype: TestClass.prototype});
-      var result = immutable.asMutable();
+      var result = Immutable.asMutable(immutable);
 
       TestUtils.assertJsonEqual(result, data);
       TestUtils.assertHasPrototype(result, TestClass.prototype);

--- a/test/ImmutableObject/test-merge.js
+++ b/test/ImmutableObject/test-merge.js
@@ -36,7 +36,7 @@ module.exports = function(config) {
           function runMerge(others) {
             others = others || list;
 
-            return immutable.merge(others, config);
+            return Immutable.merge(immutable, others, config);
           }
 
           callback(immutable, list, runMerge);
@@ -114,7 +114,7 @@ module.exports = function(config) {
       it("does not reproduce #70", function() {
         var c = Immutable({a: {b: 1}});
 
-        assert.strictEqual(c, c.merge({a: {b: 1}}, {deep: true}));
+        assert.strictEqual(c, Immutable.merge(c, {a: {b: 1}}, {deep: true}));
       });
 
       it("does nothing when merging an identical object", function() {
@@ -123,7 +123,7 @@ module.exports = function(config) {
             var identicalImmutable = Immutable(mutable);
 
             assert.strictEqual(identicalImmutable,
-              identicalImmutable.merge(mutable, {deep: true}));
+              Immutable.merge(identicalImmutable, mutable, {deep: true}));
           });
         });
       });
@@ -162,14 +162,15 @@ module.exports = function(config) {
     // Sanity check to make sure our QuickCheck logic isn't off the rails.
     it("passes a basic sanity check on canned input", function() {
       var expected = Immutable({all: "your base", are: {belong: "to us"}});
-      var actual   = Immutable({all: "your base", are: {belong: "to them"}}).merge({are: {belong: "to us"}})
+      var actual   = Immutable({all: "your base", are: {belong: "to them"}})
+      actual = Immutable.merge(actual, {are: {belong: "to us"}})
 
       TestUtils.assertJsonEqual(actual, expected);
     });
 
     it("does nothing when passed a canned merge that will result in no changes", function() {
       var expected = Immutable({all: "your base", are: {belong: "to us"}});
-      var actual   = expected.merge({all: "your base"}); // Should result in a no-op.
+      var actual   = Immutable.merge(expected, {all: "your base"}); // Should result in a no-op.
 
       assert.strictEqual(expected, actual, JSON.stringify(expected) + " did not equal " + JSON.stringify(actual));
     });
@@ -191,7 +192,7 @@ module.exports = function(config) {
         var immutable = Immutable(obj);
 
         assert.throws(function() {
-          immutable.merge(nonObj);
+          Immutable.merge(immutable, nonObj);
         }, TypeError)
       });
     });
@@ -201,12 +202,12 @@ module.exports = function(config) {
       var toMerge  = {are: {you: {have: "no chance to survive"}}};
 
       var expectedShallow = Immutable({all: "your base", are: {you: {have: "no chance to survive"}}});
-      var actualShallow   = original.merge(toMerge);
+      var actualShallow   = Immutable.merge(original, toMerge);
 
       TestUtils.assertJsonEqual(actualShallow, expectedShallow);
 
       var expectedDeep = Immutable({all: "your base", are: {belong: "to us", you: {have: "no chance to survive", make: "your time"}}});
-      var actualDeep   = original.merge(toMerge, {deep: true});
+      var actualDeep   = Immutable.merge(original, toMerge, {deep: true});
 
       TestUtils.assertJsonEqual(actualDeep, expectedDeep);
     });
@@ -216,12 +217,12 @@ module.exports = function(config) {
       var toMerge  = [{test: {b: true}}, {test: {c: true}}];
 
       var expectedShallow = Immutable({test: {c: true}});
-      var actualShallow   = original.merge(toMerge);
+      var actualShallow   = Immutable.merge(original, toMerge);
 
       TestUtils.assertJsonEqual(actualShallow, expectedShallow);
 
       var expectedDeep = Immutable({test: {a: true, b: true, c: true}});
-      var actualDeep   = original.merge(toMerge, {deep: true});
+      var actualDeep   = Immutable.merge(original, toMerge, {deep: true});
 
       TestUtils.assertJsonEqual(actualDeep, expectedDeep);
     });
@@ -231,7 +232,7 @@ module.exports = function(config) {
       var toMerge = {id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [3, 4], sub: {y: [10, 11], z: [101, 102]}};
 
       var expected = Immutable({id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [3, 4], sub: {z: [101, 102], y: [10, 11]}});
-      var actual   = original.merge(toMerge, {deep: true});
+      var actual   = Immutable.merge(original, toMerge, {deep: true});
 
       TestUtils.assertJsonEqual(actual, expected);
     });
@@ -244,7 +245,8 @@ module.exports = function(config) {
 
     it("merges with a custom merger when the config tells it to", function() {
       var expected = Immutable({all: "your base", are: {belong: "to us"}, you: ['have', 'no', 'chance', 'to', 'survive']});
-      var actual = Immutable({all: "your base", are: {belong: "to us"}, you: ['have', 'no']}).merge({you: ['chance', 'to', 'survive']}, {merger: arrayMerger});
+      var actual = Immutable({all: "your base", are: {belong: "to us"}, you: ['have', 'no']});
+      var actual = Immutable.merge(actual, {you: ['chance', 'to', 'survive']}, {merger: arrayMerger});
 
       TestUtils.assertJsonEqual(actual, expected);
     });
@@ -254,7 +256,7 @@ module.exports = function(config) {
       var toMerge = {id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [3, 4], sub: {y: [10, 11], z: [101, 102]}};
 
       var expected = Immutable({id: 3, name: "three", valid: false, a: [1000], b: {id: 4}, x: [1, 2, 3, 4], sub: {z: [100, 101, 102], y: [10, 11]}});
-      var actual   = original.merge(toMerge, {deep: true, merger: arrayMerger});
+      var actual   = Immutable.merge(original, toMerge, {deep: true, merger: arrayMerger});
 
       TestUtils.assertJsonEqual(actual, expected);
     });
@@ -262,7 +264,7 @@ module.exports = function(config) {
     it("merges with a custom merger that returns the current object the result is the same as the original", function() {
       var data = {id: 3, name: "three", valid: true, a: {id: 2}, b: [50], x: [1, 2], sub: {z: [100]}};
       var original = Immutable(data);
-      var actualWithoutMerger = original.merge(data);
+      var actualWithoutMerger = Immutable.merge(original, data);
       assert.notEqual(original, actualWithoutMerger);
 
       var config = {
@@ -270,7 +272,7 @@ module.exports = function(config) {
           return current;
         }
       };
-      var actualWithMerger = original.merge(data, config);
+      var actualWithMerger = Immutable.merge(original, data, config);
       assert.equal(original, actualWithMerger);
     });
 
@@ -280,7 +282,7 @@ module.exports = function(config) {
       var mergeData = {b: 3, c: 4};
 
       var immutable = Immutable(data, {prototype: TestClass.prototype});
-      var result = immutable.merge(mergeData);
+      var result = Immutable.merge(immutable, mergeData);
 
       TestUtils.assertJsonEqual(result, _.extend({}, data, mergeData));
       TestUtils.assertHasPrototype(result, TestClass.prototype);

--- a/test/ImmutableObject/test-set.js
+++ b/test/ImmutableObject/test-set.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
         var value = JSC.any()();
 
         TestUtils.assertJsonEqual(
-          immutable.set(prop, value),
+          Immutable.set(immutable, prop, value),
           _.set(mutable, prop, value)
         );
       });
@@ -47,7 +47,7 @@ module.exports = function(config) {
         }
 
         TestUtils.assertJsonEqual(
-          immutable.setIn(path, value),
+          Immutable.setIn(immutable, path, value),
           _.set(mutable, path, value)
         );
       });
@@ -59,7 +59,7 @@ module.exports = function(config) {
       var val = 'val';
 
       var immutable = Immutable(ob);
-      var final = immutable.setIn(path, val);
+      var final = Immutable.setIn(immutable, path, val);
 
       assert.deepEqual(final, {foo: [{bar: 'val'}]});
     });

--- a/test/ImmutableObject/test-update.js
+++ b/test/ImmutableObject/test-update.js
@@ -32,7 +32,7 @@ module.exports = function(config) {
         var prop = 'complex';
 
         TestUtils.assertJsonEqual(
-          immutable.update(prop, dummyUpdater),
+          Immutable.update(immutable, prop, dummyUpdater),
           _.set(mutable, prop, dummyUpdater(_.get(mutable, prop)))
         );
       });
@@ -45,7 +45,7 @@ module.exports = function(config) {
         var prop = 'complex';
 
         TestUtils.assertJsonEqual(
-          immutable.update(prop, dummyUpdater, "agr1", 42),
+          Immutable.update(immutable, prop, dummyUpdater, "agr1", 42),
           _.set(mutable, prop, dummyUpdater(_.get(mutable, prop), "agr1", 42))
         );
       });
@@ -63,7 +63,7 @@ module.exports = function(config) {
         var path = ['deep', 'complex'];
 
         TestUtils.assertJsonEqual(
-          immutable.updateIn(path, dummyUpdater),
+          Immutable.updateIn(immutable, path, dummyUpdater),
           _.set(mutable, path, dummyUpdater(_.get(mutable, path)))
         );
       });
@@ -79,7 +79,7 @@ module.exports = function(config) {
         var path = ['deep', 'complex'];
 
         TestUtils.assertJsonEqual(
-          immutable.updateIn(path, dummyUpdater, "agr1", 42),
+          Immutable.updateIn(immutable, path, dummyUpdater, "agr1", 42),
           _.set(mutable, path, dummyUpdater(_.get(mutable, path), "agr1", 42))
         );
       });


### PR DESCRIPTION
First commit provides the fix for #130. Add static methods to `Immutable` while remaining backward compatible with current syntax.
```
// Those are equivalent

obj.setIn(['key'], value);
Immutable.setIn(obj, ['key'], value);
```

Second commit is only a proof that it works in test units. With some addition it may actually be fine, as it also makes tests cover static and non-static methods as a side effect. But I wasn't sure if @rtfeldman would prefer any different approach. This can be updated if this PR gets any interest.

Perhaps the documentation can also be updated to promote the static methods over the non-static ones, all up to you. I'm happy to add any further commits I'm asked for.