### PR TITLE
Finish converting test units to using static methods

### DIFF
--- a/test/ImmutableArray/test-asMutable.js
+++ b/test/ImmutableArray/test-asMutable.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
   describe("#asMutable", function() {
     it("returns an empty mutable array from an empty immutable array", function() {
         var immutable = Immutable([]);
-        var mutable = immutable.asMutable();
+        var mutable = Immutable.asMutable(immutable);
 
         assertIsArray(mutable);
         assertCanBeMutated(mutable);
@@ -22,7 +22,7 @@ module.exports = function(config) {
     it("returns a shallow mutable copy if not provided the deep flag", function() {
       check(100, [ JSC.array([TestUtils.TraversableObjectSpecifier, JSC.any()]) ], function(array) {
         var immutable = Immutable(array);
-        var mutable = immutable.asMutable();
+        var mutable = Immutable.asMutable(immutable);
 
         assertIsArray(mutable);
         assertCanBeMutated(mutable);
@@ -37,7 +37,7 @@ module.exports = function(config) {
     it("returns a deep mutable copy if provided the deep flag", function() {
       check(100, [ JSC.array([TestUtils.TraversableObjectSpecifier, JSC.any()]) ], function(array) {
         var immutable = Immutable(array);
-        var mutable = immutable.asMutable({ deep: true });
+        var mutable = Immutable.asMutable(immutable, { deep: true });
 
         assertIsArray(mutable);
         assertCanBeMutated(mutable);

--- a/test/ImmutableArray/test-asObject.js
+++ b/test/ImmutableArray/test-asObject.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
           return [key, value];
         }));
 
-        var result = array.asObject(function(value, index) {
+        var result = Immutable.asObject(array, function(value, index) {
           assert.strictEqual((typeof index), "number");
 
           // Check that the index argument we receive works as expected.
@@ -36,7 +36,7 @@ module.exports = function(config) {
           return [key, value];
         }));
 
-        var result = array.asObject();
+        var result = Immutable.asObject(array);
 
         TestUtils.assertJsonEqual(result, obj);
       });
@@ -45,7 +45,8 @@ module.exports = function(config) {
     // Sanity check to make sure our QuickCheck logic isn't off the rails.
     it("passes a basic sanity check on canned input", function() {
       var expected = Immutable({all: "your base", are: {belong: "to us"}});
-      var actual   = Immutable([{key: "all", value: "your base"}, {key: "are", value: {belong: "to us"}}]).asObject(function(elem) {
+      var actual   = Immutable([{key: "all", value: "your base"}, {key: "are", value: {belong: "to us"}}]);
+      actual = Immutable.asObject(actual, function(elem) {
         return [elem.key, elem.value];
       });
 

--- a/test/ImmutableArray/test-flatMap.js
+++ b/test/ImmutableArray/test-flatMap.js
@@ -12,7 +12,7 @@ module.exports = function(config) {
     // Sanity check to make sure our QuickCheck logic isn't off the rails.
     it("passes a basic sanity check on canned input", function() {
       var expected = Immutable(["foo", "foo2", "bar", "bar2", "baz", "baz2"]);
-      var actual   = Immutable(["foo", "bar", "baz"]).flatMap(function(elem) {
+      var actual   = Immutable.flatMap(Immutable(["foo", "bar", "baz"]), function(elem) {
         return [elem, elem + "2"];
       });
 
@@ -24,7 +24,7 @@ module.exports = function(config) {
         var returnValues = array.map(function() { return JSC.any()(); });
         var iterator = function(value, index) { return returnValues[index]; };
         var expected = _.map(array, iterator);
-        var actual   = Immutable(array).flatMap(iterator);
+        var actual   = Immutable.flatMap(Immutable(array), iterator);
 
         TestUtils.assertJsonEqual(actual, expected);
       });
@@ -34,7 +34,7 @@ module.exports = function(config) {
       check(100, [JSC.array()], function(array) {
         var iterator = function(value, index) { return index; };
         var expected = _.map(array, iterator);
-        var actual   = Immutable(array).flatMap(iterator);
+        var actual   = Immutable.flatMap(Immutable(array), iterator);
 
         TestUtils.assertJsonEqual(actual, expected);
       });
@@ -45,7 +45,7 @@ module.exports = function(config) {
         var returnValues = array.map(function() { return [JSC.any()()]; });
         var iterator = function(value, index) { return returnValues[index]; };
         var expected = _.flatten(_.map(array, iterator));
-        var actual   = Immutable(array).flatMap(iterator);
+        var actual   = Immutable.flatMap(Immutable(array), iterator);
 
         TestUtils.assertJsonEqual(actual, expected);
       });
@@ -54,7 +54,7 @@ module.exports = function(config) {
     it("works the same way as flatten when called with no arguments", function() {
       check(100, [JSC.array()], function(array) {
         var expected = _.flatten(array);
-        var actual   = Immutable(array).flatMap();
+        var actual   = Immutable.flatMap(Immutable(array));
 
         TestUtils.assertJsonEqual(actual, expected);
       });
@@ -65,7 +65,7 @@ module.exports = function(config) {
       var iterator = function() { return [] };
 
       check(100, [JSC.array()], function(array) {
-        var actual = Immutable(array).flatMap(iterator);
+        var actual = Immutable.flatMap(array, iterator);
 
         TestUtils.assertJsonEqual(actual, expected);
       });

--- a/test/ImmutableObject/test-asMutable.js
+++ b/test/ImmutableObject/test-asMutable.js
@@ -37,7 +37,7 @@ module.exports = function(config) {
     it("returns a deep mutable copy if provided the deep flag", function() {
       check(100, [ TestUtils.TraversableObjectSpecifier ], function(obj) {
         var immutable = Immutable(obj);
-        var mutable = immutable.asMutable({ deep: true });
+        var mutable = Immutable.asMutable(immutable, { deep: true });
 
         assertNotArray(mutable);
         assertCanBeMutated(mutable);
@@ -51,7 +51,7 @@ module.exports = function(config) {
     it("does not throw an error when asMutable deep = true is called on an Immutable with a nested date", function() {
       check(100, [ TestUtils.TraversableObjectSpecifier ], function(obj) {
         var test = Immutable({ testDate: new Date()});
-        test.asMutable({deep: true});
+        Immutable.asMutable(test, {deep: true});
       });
     });
 

--- a/test/ImmutableObject/test-without.js
+++ b/test/ImmutableObject/test-without.js
@@ -64,16 +64,16 @@ module.exports = function(config) {
       checkImmutableWithKeys(keysSpecifier, function(immutable, keys, useVarArgs) {
 
         it("returns the same result as a corresponding without(predicate)", function() {
-          var expected = immutable.without(dropKeysPredicate(keys));
+          var expected = Immutable.without(immutable, dropKeysPredicate(keys));
           var actual   = useVarArgs ?
-            immutable.without.apply(immutable, keys) :
-            immutable.without(keys);
+            Immutable.without.apply(Immutable, [immutable].concat(keys)) :
+            Immutable.without(immutable, keys); 
           TestUtils.assertJsonEqual(actual, expected);
         });
 
         it("drops the keys", function() {
           var expectedKeys = _.difference(_.keys(immutable), keys);
-          var result = immutable.without(keys);
+          var result = Immutable.without(immutable, keys);
 
           TestUtils.assertJsonEqual(_.keys(result), expectedKeys);
         });
@@ -83,7 +83,8 @@ module.exports = function(config) {
     // Sanity check to make sure our QuickCheck logic isn't off the rails.
     it("passes a basic sanity check on canned input", function() {
       var expected = Immutable({cat: "meow", dog: "woof"});
-      var actual   = Immutable({cat: "meow", dog: "woof", fox: "???"}).without("fox");
+      var actual   = Immutable({cat: "meow", dog: "woof", fox: "???"});
+      actual = Immutable.without(actual, "fox");
 
       TestUtils.assertJsonEqual(actual, expected);
     });
@@ -91,17 +92,19 @@ module.exports = function(config) {
     // Check that numeric keys are removed too.
     it("passes a basic sanity check with numeric keys", function() {
       var expected = Immutable({cat: "meow", dog: "woof"});
-      var actual   = Immutable({cat: "meow", dog: "woof", 42: "???"}).without(42);
+      var actual   = Immutable({cat: "meow", dog: "woof", 42: "???"});
+      actual = Immutable.without(actual, 42);
       TestUtils.assertJsonEqual(actual, expected);
 
-      actual       = Immutable({cat: "meow", dog: "woof", 42: "???", 0.5: "xxx"}).without([42, 0.5]);
+      actual       = Immutable({cat: "meow", dog: "woof", 42: "???", 0.5: "xxx"});
+      actual = Immutable.without(actual, [42, 0.5]);
       TestUtils.assertJsonEqual(actual, expected);
     });
 
     it("is a no-op when passed nothing", function() {
       check(100, [TestUtils.ComplexObjectSpecifier()], function(obj) {
         var expected = Immutable(obj);
-        var actual   = expected.without();
+        var actual   = Immutable.without(expected);
 
         TestUtils.assertJsonEqual(actual, expected);
       });
@@ -112,7 +115,7 @@ module.exports = function(config) {
       var data = new TestClass({a: 1, b: 2});
 
       var immutable = Immutable(data, {prototype: TestClass.prototype});
-      var result = immutable.without('b');
+      var result = Immutable.without(immutable, 'b');
 
       TestUtils.assertJsonEqual(result, _.omit(data, 'b'));
       TestUtils.assertHasPrototype(result, TestClass.prototype);
@@ -135,7 +138,7 @@ module.exports = function(config) {
 
         it("drops the keys satisfying the predicate", function() {
           var expectedKeys = _.difference(_.keys(immutable), keys);
-          var result = immutable.without(dropKeysPredicate(keys));
+          var result = Immutable.without(immutable, dropKeysPredicate(keys));
 
           TestUtils.assertJsonEqual(_.keys(result), expectedKeys);
 
@@ -146,7 +149,7 @@ module.exports = function(config) {
         });
 
         it("returns an Immutable Object", function() {
-          var result = immutable.without(dropKeysPredicate(keys));
+          var result = Immutable.without(immutable, dropKeysPredicate(keys));
           assert.instanceOf(result, Object);
           TestUtils.assertIsDeeplyImmutable(result);
         });
@@ -156,7 +159,7 @@ module.exports = function(config) {
             return _.includes(keys, key);
           });
 
-          var actual = immutable.without(function (value, key) {
+          var actual = Immutable.without(immutable, function (value, key) {
             return _.includes(keys, key);
           });
 


### PR DESCRIPTION
This completes changes in commit https://github.com/rtfeldman/seamless-immutable/pull/158/commits/bfbf81d6641243fbb2eedf2874ff7ea94ee7e037

Such that we have all static methods under test units, and indirectly have the existing instance methods under those same test units as a side effect.

@rtfeldman Ping, and thanks for merging #158 !