### PR TITLE
Add validation for first Immutable#setIn parameter

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -454,6 +454,10 @@
   var immutableEmptyObject = Immutable({});
 
   function objectSetIn(path, value, config) {
+    if (!(path instanceof Array) || path.length === 0) {
+      throw new TypeError("The first argument to Immutable#setIn must be an array containing at least one \"key\" string.")
+    }
+
     var head = path[0];
     if (path.length === 1) {
       return objectSet.call(this, head, value, config);


### PR DESCRIPTION
Add validation for non-arrays or empty arrays being passed to Immutable#setIn. Throw a  relevant error if validation fails.

Addresses rtfeldman/seamless-immutable#157
