### PR TITLE
Make source browser-compatible

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -83,7 +83,7 @@
     // Tag it so we can quickly tell it's immutable later.
     addImmutabilityTag(obj);
 
-    if (process.env.NODE_ENV !== "production") {
+    if (process && process.env && process.env.NODE_ENV !== "production") {
       // Make all mutating methods throw exceptions.
       for (var index in bannedMethods) {
         if (bannedMethods.hasOwnProperty(index)) {
@@ -585,7 +585,7 @@
           instantiatePlainObject : (function() { return Object.create(prototype); });
       var clone = instantiateEmptyObject();
 
-      if (process.env.NODE_ENV !== "production") {
+      if (process && process.env && process.env.NODE_ENV !== "production") {
         /*jshint eqnull:true */
         if (stackRemaining == null) {
           stackRemaining = 64;


### PR DESCRIPTION
Browser doesn't contain `process` global variable which results in exception mentioned in #164
