### PR TITLE
Handle File objects

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -570,8 +570,13 @@
            (obj.$$typeof === REACT_ELEMENT_TYPE_FALLBACK || obj.$$typeof === REACT_ELEMENT_TYPE);
   }
 
+  function isFileObject(obj) {
+    return typeof File !== 'undefined' &&
+           obj instanceof File;
+  }
+
   function Immutable(obj, options, stackRemaining) {
-    if (isImmutable(obj) || isReactElement(obj)) {
+    if (isImmutable(obj) || isReactElement(obj) || isFileObject(obj)) {
       return obj;
     } else if (Array.isArray(obj)) {
       return makeImmutableArray(obj.slice());

--- a/test/Immutable.spec.js
+++ b/test/Immutable.spec.js
@@ -131,6 +131,19 @@ var getTestUtils = require("./TestUtils.js");
         TestUtils.assertJsonEqual(immutableElement, reactElement);
       });
 
+      it("doesn't modify File objects", function() {
+        global.File = TestUtils.FileMock;
+
+        var file = new File(['part'], 'filename.jpg');
+        var immutableFile = Immutable(file);
+
+        assert.typeOf(immutableFile, 'object');
+        assert.isTrue(immutableFile instanceof File);
+        TestUtils.assertJsonEqual(immutableFile, file);
+
+        delete global.File;
+      });
+
       it("detects cycles", function() {
         var obj = {};
         obj.prop = obj;

--- a/test/TestUtils.js
+++ b/test/TestUtils.js
@@ -130,6 +130,14 @@ function isDeepEqual(a, b) {
   return (deepEqual(a, b) || (a !== a && b !== b));
 }
 
+// window.File mock
+function File(parts, filename) {
+  this.name = 'ok';
+  this.size = 4;
+  this.lastModifiedDate = new Date();
+  this.lastModified = this.lastModifiedDate.getTime();
+}
+
 module.exports = function(Immutable) {
   return {
     assertJsonEqual:         assertJsonEqual,
@@ -141,6 +149,7 @@ module.exports = function(Immutable) {
     TraversableObjectSpecifier: TraversableObjectSpecifier,
     check:                   check,
     checkImmutableMutable:   wrapCheckImmutableMutable(Immutable),
-    isDeepEqual:             isDeepEqual
+    isDeepEqual:             isDeepEqual,
+    FileMock:                File,
   }
 };


### PR DESCRIPTION
This is intended as a fix for `window.File`, which should not be made immutable (like React elements).

Resolves #142