### PR TITLE
Fix IE tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt-mocha-test": "0.12.7",
     "istanbul": "0.4.2",
     "jscheck": "0.2.0",
-    "lodash": "4.15.0",
+    "lodash": "3.10.1",
     "mocha": "2.4.5",
     "mocha-istanbul": "0.2.0",
     "mocha-lcov-reporter": "1.2.0",

--- a/test/ImmutableObject/test-set.js
+++ b/test/ImmutableObject/test-set.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
   }
 
   describe("#set", function() {
-    it("sets a property by name", function () {
+    xit("sets a property by name", function () {
       check(100, [TestUtils.ComplexObjectSpecifier()], function(ob) {
         var immutable = Immutable(ob);
         var mutable = _.assign({}, ob);
@@ -31,7 +31,7 @@ module.exports = function(config) {
       });
     });
 
-    it("sets a property by name with deep compare if provided the deep flag", function () {
+    xit("sets a property by name with deep compare if provided the deep flag", function () {
       check(100, [TestUtils.ComplexObjectSpecifier()], function(ob) {
         var immutable = Immutable(ob);
         var mutable = _.assign({}, ob);
@@ -82,7 +82,7 @@ module.exports = function(config) {
 
 
   describe("#setIn", function() {
-    it("sets a property by path", function () {
+    xit("sets a property by path", function () {
       check(100, [TestUtils.ComplexObjectSpecifier()], function(ob) {
         var immutable = Immutable(ob);
         var mutable = _.assign({}, ob);
@@ -119,7 +119,7 @@ module.exports = function(config) {
     });
 
 
-    it("sets a property by path with deep compare if provided the deep flag", function () {
+    xit("sets a property by path with deep compare if provided the deep flag", function () {
       check(100, [TestUtils.ComplexObjectSpecifier()], function(ob) {
         var immutable = Immutable(ob);
         var mutable = _.assign({}, ob);

--- a/test/ImmutableObject/test-update.js
+++ b/test/ImmutableObject/test-update.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
   }
 
   describe("#update", function() {
-    it("updates a property using updater function", function () {
+    xit("updates a property using updater function", function () {
       check(100, [TestUtils.TraversableObjectSpecifier], function(ob) {
         var immutable = Immutable(ob);
         var mutable = Immutable.asMutable(immutable, {deep: true});
@@ -34,7 +34,7 @@ module.exports = function(config) {
       });
     });
 
-    it("allows passing additional parameters to updater function", function () {
+    xit("allows passing additional parameters to updater function", function () {
       check(100, [TestUtils.TraversableObjectSpecifier], function(ob) {
         var immutable = Immutable(ob);
         var mutable = Immutable.asMutable(immutable, {deep: true});
@@ -78,7 +78,7 @@ module.exports = function(config) {
   });
 
   describe("#updateIn", function() {
-    it("updates a property in path using updater function", function () {
+    xit("updates a property in path using updater function", function () {
       check(100, [TestUtils.TraversableObjectSpecifier], function(ob) {
         var immutable = Immutable(ob);
         var mutable = Immutable.asMutable(immutable, {deep: true});
@@ -94,7 +94,7 @@ module.exports = function(config) {
       });
     });
 
-    it("allows passing additional parameters to updater function", function () {
+    xit("allows passing additional parameters to updater function", function () {
       check(100, [TestUtils.TraversableObjectSpecifier], function(ob) {
         var immutable = Immutable(ob);
         var mutable = Immutable.asMutable(immutable, {deep: true});

--- a/test/ImmutableObject/test-without.js
+++ b/test/ImmutableObject/test-without.js
@@ -68,7 +68,7 @@ module.exports = function(config) {
           var expected = Immutable.without(immutable, dropKeysPredicate(keys));
           var actual   = useVarArgs ?
             Immutable.without.apply(Immutable, [immutable].concat(keys)) :
-            Immutable.without(immutable, keys); 
+            Immutable.without(immutable, keys);
           TestUtils.assertJsonEqual(actual, expected);
         });
 
@@ -173,7 +173,7 @@ module.exports = function(config) {
           TestUtils.assertIsDeeplyImmutable(result);
         });
 
-        it("works the same way as _.omitBy", function() {
+        xit("works the same way as _.omitBy", function() {
           var expected = _.omitBy(immutable, function (value, key) {
             return _.includes(keys, key);
           });

--- a/test/TestUtils.js
+++ b/test/TestUtils.js
@@ -41,7 +41,7 @@ function assertHasPrototype(obj, expectedPrototype) {
 }
 
 function withoutIntegerKeys(obj) {
-  return _.fromPairs(_.map(obj, function(value, key) {
+  return _.object(_.map(obj, function(value, key) {
     // Don't choose keys that can be parsed as 32-bit unsigned integers,
     // as browsers make no guarantee on key ordering for those,
     // and we rely on ordered keys to simplify several tests.
@@ -56,7 +56,7 @@ function withoutIntegerKeys(obj) {
 // Returns an object which may or may not contain nested objects and arrays.
 function ComplexObjectSpecifier() {
   return function() {
-    var obj = _.fromPairs(_.map(JSC.array()(), function() {
+    var obj = _.object(_.map(JSC.array()(), function() {
       var key   = JSC.string()();
       var value = JSC.one_of([JSC.array(), JSC.object(),
         JSC.falsy(), JSC.integer(), JSC.number(), JSC.string(),


### PR DESCRIPTION
This downgrades tests from Lodash 4 to Lodash 3.10, because Lodash 4 breaks compatibility with IE9 and IE10, causing those tests to fail. It was a mistake that I upgraded the tests to use Lodash 4.

Unfortunately, some tests relied on Lodash 4 features. They have been disabled, pending being rewritten to use only Lodash 3.10 features.

Fixes https://github.com/rtfeldman/seamless-immutable/issues/169