### PR TITLE
Fix broken release: Don't exclude built files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -38,7 +38,4 @@ Gruntfile.js
 bower.json
 .zuul.yml
 benchmark.js
-seamless-immutable.development.min.js
-seamless-immutable.development.js
-seamless-immutable.production.min.js
 test


### PR DESCRIPTION
The latest release didn't include the produciton and development builds since they were included in `.npmignore`.