### PR TITLE
special-case errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We generally recommend to use the "development" build that enforces immutability
 
 ## Intentional Abstraction Leaks
 
-By popular demand, functions, dates, and [React](https://facebook.github.io/react/)
+By popular demand, functions, errors, dates, and [React](https://facebook.github.io/react/)
 components are treated as immutable even though technically they can be mutated.
 (It turns out that trying to make these immutable leads to more bad things
 than good.) If you call `Immutable()` on any of these, be forewarned: they will

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -617,8 +617,12 @@ function immutableInit(config) {
            typeof obj.then === 'function';
   }
 
+  function isError(obj) {
+    return obj instanceof Error;
+  }
+
   function Immutable(obj, options, stackRemaining) {
-    if (isImmutable(obj) || isReactElement(obj) || isFileObject(obj)) {
+    if (isImmutable(obj) || isReactElement(obj) || isFileObject(obj) || isError(obj)) {
       return obj;
     } else if (isPromise(obj)) {
       return obj.then(Immutable);

--- a/test/Immutable.spec.js
+++ b/test/Immutable.spec.js
@@ -164,6 +164,12 @@ var getTestUtils = require("./TestUtils.js");
         delete global.File;
       });
 
+      it("doesn't modify Error objects", function () {
+        var error = new Error('Oh no something bad happened!');
+        var immutableError = Immutable(error);
+        assert.strictEqual(error, immutableError, 'Immutable should pass the error directly through')
+      });
+
       it("detects cycles", function() {
         var obj = {};
         obj.prop = obj;


### PR DESCRIPTION
Hey! We're working with some folks who want to bring seamless-immutable into their stack, and as part of setting things up we found that Error objects come out the other side of `Immutable()` as empty objects. Error properties are exposed as getters on the prototype so the standard method of copying objects doesn't work out.

Thanks Richard!