### PR TITLE
Update static/instance example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Immutable.merge(obj, {are: {belong: "to us"}})
 
 Seamless-immutable supports both static and instance syntaxes:
 
-```
+```javascript
 var Immutable = require("seamless-immutable").static;
 
 Immutable.setIn(obj, ['key'], data)
 ```
 
-```
+```javascript
 var Immutable = require("seamless-immutable");
 
 obj.setIn(['key'], data)

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ Seamless-immutable supports both static and instance syntaxes:
 ```
 var Immutable = require("seamless-immutable").static;
 
-Immutable.setIn(obj, 'key', data)
+Immutable.setIn(obj, ['key'], data)
 ```
 
 ```
 var Immutable = require("seamless-immutable");
 
-obj.setIn('key', data)
+obj.setIn(['key'], data)
 ```
 
 Although the later is shorter and is the current default, it can lead to

--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ Seamless-immutable supports both static and instance syntaxes:
 
 ```javascript
 var Immutable = require("seamless-immutable").static;
+var obj = {};
 
 Immutable.setIn(obj, ['key'], data)
 ```
 
 ```javascript
 var Immutable = require("seamless-immutable");
+var obj = {};
 
 obj.setIn(['key'], data)
 ```


### PR DESCRIPTION
The static/instance example in the README was calling `setIn` without giving the key "chain" as a array.