### PR TITLE
Use `Array.isArray` instead of `instanceof Array`

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -484,7 +484,7 @@ function immutableInit(config) {
   var immutableEmptyObject = Immutable({});
 
   function objectSetIn(path, value, config) {
-    if (!(path instanceof Array) || path.length === 0) {
+    if (!(Array.isArray(path)) || path.length === 0) {
       throw new TypeError("The first argument to Immutable#setIn must be an array containing at least one \"key\" string.");
     }
 


### PR DESCRIPTION
:wave: We've been using this library for a while at [goabstract.com](http://goabstract.com) and I just hit a snag while upgrading from 6.3.0 to 7.1.2. We run our tests with karma and karma-electron-launcher, which uses an iframe to run tests. When I upgraded to 7.1.2, I started getting all sorts of errors from inside of seamless-immutable, saying `The first argument to Immutable#setIn must be an array containing at least one "key" string` even though I was definitely passing a non-empty array of strings as the first argument to that function. After a while, I realized that, inside of seamless-immutable, `path instanceof Array` was returning false.

It turns out that [MDN recommends](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#instanceof_vs_isArray) `Array.isArray` over `instanceof Array`, saying

> When checking for Array instance, Array.isArray is preferred over instanceof because it works through iframes.

I've confirmed that this change fixes the iframe issue and that `Array.isArray` is compatible with the browsers that seamless-immutable tests against. If compatibility is a concern, though, I could add a very small polyfill to this PR.

Thanks @rtfeldman!