### PR TITLE
Add jsdom to fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-- '5.0'
+- '8.10'
 
 before_script:
 - npm install

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -9,4 +9,4 @@ browsers:
   - name: android
     version: ["5.0", "5.1", "6.0"]
   - name: safari
-    version: ["6", "latest"]
+    version: ["7", "latest"]

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -10,4 +10,3 @@ browsers:
     version: ["5.0", "5.1", "6.0"]
   - name: safari
     version: ["7", "latest"]
-concurrency: 1

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -10,3 +10,4 @@ browsers:
     version: ["5.0", "5.1", "6.0"]
   - name: safari
     version: ["7", "latest"]
+concurrency: 1

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -7,6 +7,6 @@ browsers:
   - name: firefox
     version: ["36", "latest"]
   - name: android
-    version: ["4.0", "latest"]
+    version: ["5.0", "5.1", "6.0"]
   - name: safari
     version: ["6", "latest"]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "grunt-mocha-test": "0.12.7",
     "istanbul": "0.4.2",
     "jscheck": "0.2.0",
+    "jsdom": "11.6.2",
+    "jsdom-global": "3.0.2",
     "lodash": "3.10.1",
     "mocha": "2.4.5",
     "mocha-istanbul": "0.2.0",

--- a/test/Immutable.spec.js
+++ b/test/Immutable.spec.js
@@ -1,3 +1,4 @@
+require('jsdom-global')()
 var JSC          = require("jscheck");
 var assert       = require("chai").assert;
 var _            = require("lodash");

--- a/test/TestUtils.js
+++ b/test/TestUtils.js
@@ -141,8 +141,6 @@ module.exports = function(Immutable) {
     TraversableObjectSpecifier: TraversableObjectSpecifier,
     check:                   check,
     checkImmutableMutable:   wrapCheckImmutableMutable(Immutable),
-    isDeepEqual:             isDeepEqual,
-    FileMock:                File,
-    BlobMock:                Blob
+    isDeepEqual:             isDeepEqual
   }
 };


### PR DESCRIPTION
Do not merge this. It has degenerated into a cat and mouse game with Saucelabs :)

@rtfeldman the tests are failing. It seems like it's because of `File` and `Blob` not being available in Node.

This PR adds jsdom and initializes it in `Immutable.spec.js`, the only place where those are used. I also removed a few unused exports in `TestUtils` (which should be undefined anyway).