### PR TITLE
Update README.md Releases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Returns a mutable copy of the object. For a deeply mutable copy, in which any in
 
 ### Releases
 
-#### 7.1.2
+#### 7.1.3
 
 Treat `Blob` instances as immutable. Use `Array.isArray` over `instanceof`.
 


### PR DESCRIPTION
The releases sections referred to `7.1.2` twice.

Replaced the more recent declaration of `7.1.2` to `7.1.3` as it's the latest version.