### PR TITLE
replace() uses the passed in merger

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -467,7 +467,8 @@ function immutableInit(config) {
   }
 
   function objectReplace(value, config) {
-    var deep          = config && config.deep;
+    var deep          = config && config.deep,
+        merger        = config && config.merger;
 
     // Calling .replace() with no arguments is a no-op. Don't bother cloning.
     if (arguments.length === 0) {
@@ -478,7 +479,7 @@ function immutableInit(config) {
       throw new TypeError("Immutable#replace can only be invoked with objects or arrays, not " + JSON.stringify(value));
     }
 
-    return Immutable.merge(this, value, {deep: deep, mode: 'replace'});
+    return Immutable.merge(this, value, {deep: deep, merger: merger, mode: 'replace'});
   }
 
   var immutableEmptyObject = Immutable({});


### PR DESCRIPTION
I have a use case where I need to use a customized merger to compare deep array equality, and this seems to work for `merge()` but not where I need it, which is `replace()`.  So, I've updated it to take the same merger function as `merge()`.