### PR TITLE
Blob, File and React Elements are not mergable

### DIFF
--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -73,7 +73,7 @@ function immutableInit(config) {
   }
 
   function isMergableObject(target) {
-    return target !== null && typeof target === "object" && !(Array.isArray(target)) && !(target instanceof Date);
+    return target !== null && typeof target === "object" && !(Array.isArray(target)) && !(target instanceof Date) && !isBlobObject(target) && !isFileObject(target) && !isReactElement(target);
   }
 
   var mutatingObjectMethods = [


### PR DESCRIPTION
fixes #265 `isMergableObject` checks for Blobs, Files and React elements and will not perform deep merge in those cases.