### PR TITLE
Identify react elements properly on IE 11

### DIFF
--- a/seamless-immutable.development.js
+++ b/seamless-immutable.development.js
@@ -4,8 +4,7 @@
 function immutableInit(config) {
 
   // https://github.com/facebook/react/blob/v15.0.1/src/isomorphic/classic/element/ReactElement.js#L21
-  var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element');
-  var REACT_ELEMENT_TYPE_FALLBACK = 0xeac7;
+  var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')) || 0xeac7;
 
   var globalConfig = {
     use_static: false
@@ -603,8 +602,7 @@ function immutableInit(config) {
   // https://github.com/facebook/react/blob/v15.0.1/src/isomorphic/classic/element/ReactElement.js#L326
   function isReactElement(obj) {
     return typeof obj === 'object' &&
-           obj !== null &&
-           (obj.$$typeof === REACT_ELEMENT_TYPE_FALLBACK || obj.$$typeof === REACT_ELEMENT_TYPE);
+           obj !== null && obj.$$typeof === REACT_ELEMENT_TYPE;
   }
 
   function isFileObject(obj) {

--- a/src/seamless-immutable.js
+++ b/src/seamless-immutable.js
@@ -4,8 +4,7 @@
 function immutableInit(config) {
 
   // https://github.com/facebook/react/blob/v15.0.1/src/isomorphic/classic/element/ReactElement.js#L21
-  var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element');
-  var REACT_ELEMENT_TYPE_FALLBACK = 0xeac7;
+  var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')) || 0xeac7;
 
   var globalConfig = {
     use_static: false
@@ -602,9 +601,7 @@ function immutableInit(config) {
   // Returns true if object is a valid react element
   // https://github.com/facebook/react/blob/v15.0.1/src/isomorphic/classic/element/ReactElement.js#L326
   function isReactElement(obj) {
-    return typeof obj === 'object' &&
-           obj !== null &&
-           (obj.$$typeof === REACT_ELEMENT_TYPE_FALLBACK || obj.$$typeof === REACT_ELEMENT_TYPE);
+    return typeof obj === 'object' && obj !== null && obj.$$typeof === REACT_ELEMENT_TYPE;
   }
 
   function isFileObject(obj) {


### PR DESCRIPTION
This was failing on IE 11 but now it is working properly.